### PR TITLE
delegation: use bash variables; mention near-units

### DIFF
--- a/getting-started/near-token/token-delegation.md
+++ b/getting-started/near-token/token-delegation.md
@@ -82,9 +82,6 @@ The default HD path for the NEAR app on Ledger devices is `44'/397'/0'/0'/1'`. S
 >  Signing a transaction with the wrong Ledger key can help associating multiple accounts of a user, since even failed transactions are recorded to the blockchain and can be subsequently analyzed. 
 
 
-In Windows, you can replace all the `export` commands with `set`:
-
-    set HD_PATH="account 44'/397'/0'/0'/2'"
 
 ## 1. Lockup Contracts Delegation
 

--- a/getting-started/near-token/token-delegation.md
+++ b/getting-started/near-token/token-delegation.md
@@ -526,7 +526,7 @@ View call: valeraverim.pool.f863973.m0.get_account({"account_id": "meerkat.testn
 }
 ```
 
-The staked balance in this example is `100663740438210643632989745`, or `100.66` $NEAR (reminder: you can easily convert these using `near-units -h 100663740438210643632989745`).
+The staked balance in this example is `100663740438210643632989745`, or `100.66` $NEAR (reminder: you can easily convert these using `near-units -h 100663740438210643632989745yN`).
 
 A pool's rewards only compound if it has been "pinged", which means either having a direct action performed on it \(like someone delegating or undelegating\) or if the `ping` method is called on it once within a particular epoch. This is important to do if you run a pool and want your delegators to see updated reward balances.
 

--- a/getting-started/near-token/token-delegation.md
+++ b/getting-started/near-token/token-delegation.md
@@ -61,6 +61,10 @@ It will also be helpful to set some variables, which we will use in commands bel
     export LOCKUP_ID=#your lockup contract address
     export POOL_ID=#your staking pool
     
+If you're using Windows, you can replace all the `export` commands with `set`:
+
+    set ACCOUNT_ID=#your account id
+
 You can check that you set these correctly with `echo`:
 
     echo $ACCOUNT_ID

--- a/getting-started/near-token/token-delegation.md
+++ b/getting-started/near-token/token-delegation.md
@@ -333,7 +333,13 @@ Check that it looks correct:
 echo $AMOUNT
 ```
 
-And now unstake:
+And maybe also using `near-units`:
+
+```bash
+near-units -h $AMOUNT yN
+```
+
+And now unstake!
 
 ```bash
 near call $LOCKUP_ID unstake '{

--- a/getting-started/near-token/token-delegation.md
+++ b/getting-started/near-token/token-delegation.md
@@ -340,7 +340,7 @@ And maybe also using `near-units`:
 near-units -h $AMOUNT yN
 ```
 
-And now unstake!
+And now unstake:
 
 ```bash
 near call $LOCKUP_ID unstake '{


### PR DESCRIPTION
* To save people from needing to modify every command they copy-paste, instruct them to set bash variables, `export ACCOUNT_NAME=whatever`, so that subsequent commands can be copy-pasted without modification
* Mention how to make this all work on Windows
* Always show non-Ledger and Ledger versions of `call` commands
* Mention that converting between $NEAR and yoctoNEAR can be simplified with the `near-units` library
* Fix incorrect statement about gas units
* Add `--gas` to more example commands (possibly not enough of them)
* Clean up other examples and language that's less relevant now that proper variables are used throughout