### PR TITLE
add near-sdk.io as primary link to Rust docs

### DIFF
--- a/developer/dev-docs.md
+++ b/developer/dev-docs.md
@@ -14,7 +14,10 @@ NEAR API Quick Reference: [https://docs.near.org/docs/api/naj-quick-reference](h
 
 NEAR API TypeDocs: [https://near.github.io/near-api-js/](https://near.github.io/near-api-js/)
 
-NEAR SDK Rust Docs: [https://docs.rs/near-sdk/3.1.0/near\_sdk/](https://docs.rs/near-sdk/3.1.0/near_sdk/)
+NEAR SDK Rust Docs: 
+
+- [https://www.near-sdk.io](https://www.near-sdk.io)
+- [https://docs.rs/near-sdk/3.1.0/near\_sdk/](https://docs.rs/near-sdk/3.1.0/near_sdk/)
 
 NEAR RPC Endpoints: [https://docs.near.org/docs/api/rpc](https://docs.near.org/docs/api/rpc)
 

--- a/technology/technical-documentation.md
+++ b/technology/technical-documentation.md
@@ -8,7 +8,9 @@
 
 ### SDK for building smart contracts
 
-* Rust SDK: [https://docs.near.org/docs/develop/contracts/rust/near-sdk-rs](https://docs.near.org/docs/develop/contracts/rust/near-sdk-rs)
+* Rust SDK: 
+  * [https://www.near-sdk.io](https://www.near-sdk.io)
+  * [https://docs.near.org/docs/develop/contracts/rust/near-sdk-rs](https://docs.near.org/docs/develop/contracts/rust/near-sdk-rs)
 * AssemblyScript SDK: [https://docs.near.org/docs/develop/contracts/as/intro](https://docs.near.org/docs/develop/contracts/as/intro)
 
 ### APIs for using blockchain


### PR DESCRIPTION
Update references for Rust SDK