### PR TITLE
Add link to Portuguese translation

### DIFF
--- a/network/validator-guides/running-a-validator.md
+++ b/network/validator-guides/running-a-validator.md
@@ -5,6 +5,7 @@
 ### Translations
 
 * [Korean](running-a-validator-kr.md)
+* [Portuguese](running-a-validator-pt.md)
 * Add your language too via [Github pull request](https://github.com/near/docs/pull/385)
 
 ### _READ THIS QUICKSTART GUIDE BEFORE YOU START_


### PR DESCRIPTION
The English page only had a link to the Korean translation. Add Portuguese as well.

This is a follow-up to https://github.com/near/docs/pull/816.