### PR TITLE
Translate FAQ and About pages to Portuguese

### DIFF
--- a/validators-and-staking/about-pt.md
+++ b/validators-and-staking/about-pt.md
@@ -1,0 +1,79 @@
+---
+id: staking-overview
+title: Orientações sobre Staking
+sidebar_label: Orientações
+---
+
+# Sobre (PT)
+## Traduções
+
+* [Inglês](about.md)
+* Adicione seu idioma também através do [Github pull request](https://github.com/near/docs/pull/385)
+
+## Bem Vindo
+
+Nesta seção você será introduzido aos princípios do staking e a como rodar seu próprio nó validador.
+
+Protocolo NEAR usa Proof-of-Stake (PoS) para fazer a segurança da blockchain. Os _Validadores_ são a comunidade de operadores de nó que tomam conta do [consenso da blockchain](../roles/integrator/faq/#which-consensus-algorithm-does-near-use). Tecnicamente, os _nós validadores_ são servidores que agregam transações em blocos, os executam, e mantém o último estado da blockchain. Os donos desses nós, os _Validadores_, ganham prêmios por seu serviço no final de cada época (\~12 horas).
+
+Todos os Validadores devem deixar uma certa quantia de tokens NEAR em _stake_, o que representa um colateral contra um possível comportamento desonesto. _Tokens em stake_ não podem ser gastos: se um Validador desonesto atacar o consenso da blockchain, o protocolo progressivamente destrói seu stake (veja [slashing](faq.md#what-is-a-slashing-behavior)). Tokens em Stake podem ser _desbloqueados_ a qualquer momento, mas continuam sem poder ser gastos por três épocas, mesmo que o nó validador fique offline ou decida parar de validar.
+
+O protocolo NEAR escolhe automaticamente os melhores validadores com um leilão. Qualquer um que esteja executando um nó de validação pode participar fazendo stake de seus tokens. No final de cada época, o protocolo NEAR seleciona automaticamente os nós com a maior participação, tornando-os elegíveis para gerar novos blocos e obter recompensas. Se o stake é pequeno demais, o nó de validação não receberá um _lugar de validador_ e funcionará como um nó de retransmissão normal, esperando pela próxima época (veja a [dinâmica de mercado](validators/validator-economics.md#understand-market-dynamics) na página da economia de validador).
+
+Validadores podem aumentar seu stake, e assim suas recompensas, pedindo _delegação_. Delegação é a oportunidade para todos os titulares de tokens participarem em parceria com um validador, alugando uma pequena porção do seu nó de validação. _Delegadores_ podem travar seus fundos em uma [_staking pool_](https://github.com/near/core-contracts), e receber recompensas no final de cada época, menos as taxas pagas ao Validador.
+
+As recompensas NEAR são previsíveis e proporcionais ao seu stake. O protocolo gera novos tokens a uma taxa de \~5% da oferta total (anualizada) e a maioria deles são recompensas. Como exemplo, se a oferta total for um bilhão de tokens, e as recompensas anuais forem \~4.5%, todos os validadores dividirão 45 milhões de tokens NEAR (veja a [página sobre economia](validators/validator-economics.md) para mais detalhes). Independente de você ser validador ou delegador, quanto mais stake você faz, maior é a sua parte dessas recompensas.
+
+## Para Delegadores
+
+Se você quer recompensas por fazer staking, mas não quer executar seu próprio nó de validação, mesmo assim gaste algum tempo para conhecer a economia da NEAR e o que é preciso para se tornar um grande validador. Estes são alguns bons pontos de partida:
+
+1. Entenda a [economia de um validador(validators/validator-economics.md)
+2. Veja os validadores atuais no [explorador de blocos](https://explorer.near.org/nodes/validators). Colete informações sobre sua confiabilidade, taxas e stake atual.
+3. Planeje adequadamente sua custódia de tokens, a partir das [opções de custódia disponíveis](../ecosystem/near-token/token-custody.md).
+4. Verifique o que os validadores oferecem para você, pergunte se eles usam a [staking pool](https://github.com/near/core-contracts) dos contratos principais NEAR ou seus próprios contratos inteligentes.
+5. Se você é proficiente com a interface de linha de comando, consulte a [página sobre delegação](../ecosystem/near-token/token-delegation.md) para obter uma lista de comandos de baixo nível que você pode usar para fazer stake.
+6. Junte-se aos canais dos validadores no [Discord](https://near.chat) para fazer perguntas e conhecer a comunidade de staking da NEAR.
+
+> **você sabia?**
+>
+> O protocolo NEAR não pune os delegadores. Então, se o seu validador favorito errar e for cortado, você só perderá algumas recompensas, e seu stake permanecerá intacto.
+
+## Para Validadores
+
+Você decidiu ver o quão fundo é o buraco do coelho? Sem problemas! A NEAR é como muitas outras redes de proof of stake: mantenha os seus servidores online \~100% do tempo, esteja sempre pronto para atualizar seu nó, participe da comunidade. No entanto, há fatores de diferenciação importantes, como o staking através de contratos inteligentes; atualizações planejadas do protocolo sem hard forks; taxas de gás que queimam tokens em vez de dar recompensas.
+
+Você pode encontrar material adicional a seguir:
+
+1. Entenda a [economia de um validador](validators/validator-economics.md)
+2. Verifique os [comandos de staking](validator-guides/running-a-validator.md) básicos
+3. Implante sua staking pool a partir dos [contratos principais](https://github.com/near/core-contracts)
+
+Você ainda está aqui? Se você quiser aprender mais sobre a NEAR, confira
+
+* [O Guia do Iniciante para a Blockchain da NEAR](https://near-portuguese.medium.com/o-guia-do-iniciante-para-a-blockchain-da-near-7776317b6c65) para obter uma visão geral de alto nível da NEAR.
+* [O Whitepaper da NEAR](https://near.org/papers/the-official-near-white-paper) para ver um panorama geral.
+* [Economia em Blockchain Compartilhada](https://near.org/papers/economics-in-sharded-blockchain/) para saber mais sobre a estrutura de incentivos da NEAR.
+* [Design de Compartilhamento: Nightshade](https://near.org/papers/nightshade) para ganhar um entendimento mais detalhado do mecanismo de consenso.
+
+Se algo não estiver claro ou você travar, por favor, vá ao nosso chat oficial no [Discord](https://near.chat), e entre na seção de validadores.
+
+> **Atenção!**
+>
+> Depois de abrir o link do Discord acima, você deve concluir uma verificação automática e habilitar seu papel como "validador", caso contrário, não poderá enviar mensagens nos canais de validadores.
+
+## Rede de Testes Stake Wars
+
+A Stake Wars foi a `testnet` incentivada pela NEAR para validadores profissionais. Esta iniciativa já terminou, mas ainda é possível aprender com ela.
+
+A [MainNet](https://explorer.near.org) da NEAR agora é "governada pela comunidade" (veja [o cronograma completo](https://near.org/blog/mainnet-roadmap/) e o [blog de lançamento](https://near.org/blog/near-mainnet-phase-2-unrestricted-decentralized/)) então qualquer validador pode participar. No entanto, a rede está sendo executada em um único shard, limitando temporariamente os slots disponíveis para validadores. Como resultado, você pode precisar de uma grande quantidade de tokens (em torno de 1% do stake total) para ter o seu nó _eleito_ como um produtor de blocos, e receber as recompensas.
+
+Enquanto a rede está recebendo shards adicionais e se tornando mais acessível para validadores menores, você ainda pode usar o [repositório Stake Wars](https://github.com/nearprotocol/stakewars) para entender as necessidades tecnológicas, testar a estabilidade do seu sistema e aprender alguns dos aspectos exclusivos da delegação de NEAR em preparação para a próxima fase do protocolo.
+
+Se você quiser saber mais sobre esta oportunidade, leia a publicação ["Stake Wars is Over, mas estamos apenas começando"](https://near.org/blog/stake-wars-is-over-but-were-just-getting-started/) no blog.
+
+> Tem alguma dúvida? [Pergunte no StackOverflow!](https://stackoverflow.com/questions/tagged/nearprotocol)
+
+### Junte-se à _Shards Alliance_
+
+{% embed url="https://openshards.io" %}

--- a/validators-and-staking/about.md
+++ b/validators-and-staking/about.md
@@ -6,6 +6,11 @@ sidebar_label: Orientation
 
 # About
 
+## Translations
+
+* [Portuguese](about-pt.md)
+* Add your language too via [Github pull request](https://github.com/near/docs/pull/385)
+
 ## Welcome
 
 This section introduces you to staking principles and running your validating node.

--- a/validators-and-staking/faq-pt.md
+++ b/validators-and-staking/faq-pt.md
@@ -1,0 +1,119 @@
+# FAQ (PT)
+
+## Traduções
+
+* [Inglês](faq.md)
+* Adicione seu idioma também através do [Github pull request](https://github.com/near/docs/pull/385)
+
+## O que é um validador?
+
+Usamos o termo validador para se referir a um nó que esteja engajado na construção e manutenção da rede. Existem três papéis para os quais os validadores são automaticamente selecionados:
+
+1. Produtor de bloco
+2. Produtor de pedaço de bloco
+3. Pescadores são validadores
+
+O produtor de bloco é responsável pela criação e transmissão do bloco que contém todos os pedaços atuais (blocos de fragmentos). Em comparação, o produtor de pedaços de blocos coleta transações para o fragmento dado.
+
+A coleção de transações para o fragmento é chamada de um pedaço (chunk). Uma vez criado um pedaço e um bloco, a informação têm de ser comunicada a outros produtores de pedaços, pescadores e outros nós validadores na rede. Os pescadores e outros nós validadores fornecem segurança verificando a validade das transições de estado em blocos diferentes.
+
+## Como posso me tornar um validador?
+
+Você precisa de uma conta com valor suficiente de fundos. Siga a documentação [aqui](/docs/validator/staking) para entender como se tornar um validador, e [aqui](/docs/develop/node/validator/running-a-node) para executar um nó.
+
+Passos mais específicos:
+1. Crie um novo par de chaves que será usado para staking, para determinada conta, e carregá-lo com os fundos que você deseja colocar em stake
+2. Inicie um nó com o novo par de chaves armazenado em `validator_key.json`
+3. Envie uma transação de staking usando sua carteira / CLI com sua conta, incluindo o valor e a chave pública do par de chaves recém-geradas.
+4. Aguarde até que o nó se torne um validador
+
+>  **heads up**\
+> \
+>  Os validadores externos não podem se juntar à MainNet nem à TestNet, só podem testar seus nós na BetaNet. Mais informações abaixo
+
+## O que é 'staking'?
+
+Chamamos de staking um processo de envio de `StakeTransaction` que informa a rede que uma determinada conta deseja se tornar um validador nas próximas épocas. Este tipo específico de transação deve fornecer uma chave pública e um valor de staking. Depois que a transação for enviada, um nó que tenha uma chave privada associada com a chave pública da transação de staking deve esperar até duas épocas para se tornar um validador. **importante**: um nó pode se tornar um validador somente se o valor na transação de staking estiver acima do preço do lugar definido pelo protocolo.
+
+## O que é uma época?
+
+Uma época é o intervalo de tempo que consiste de várias rodadas de consenso. Note-se que não há garantia do número exato de rodadas de consenso. Atualmente, uma época dura cerca de metade de um dia e é usada para
+
+* Medir o desempenho e uptime dos validadores
+* Coletar as ofertas dos novos validadores
+
+Para uma época, os validadores são atribuídos aleatoriamente em shards. Depois que a época acabar, os validadores são reorganizados e atribuídos a shards diferentes. Os validadores participam de várias rodadas de validação no decorrer da época. Para cada rodada, um dos validadores em cada shard é escolhido como produtor de chunks e um validador é escolhido de todo o conjunto de validadores para ser o produtor de blocos.
+
+## Qual é a quantia mínima que deve ser colocada em stake como um validador?
+
+Na MainNet, a quantidade mínima é dinâmica e é definida pela quantidade de tokens NEAR colocados em stake por outros validadores.
+
+## O que é um comportamento de slashing?
+
+Para dar segurança à sua rede Proof-of-Stake, o protocolo NEAR pune os validadores que fazem transições de estado inválidas. Um exemplo é a assinatura de dois blocos com a mesma altura (isso também é definido como um 'equívoco'). Quando isso acontece, o stake do validador é progressivamente destruído ou 'cortado', com base na entidade do ataque.
+
+## O protocolo NEAR aplica slashing por falta de atividade?
+
+Não. No entanto, o protocolo mede a atividade de cada validador e se os blocos gerados forem menos de 90% do esperado, o nó será expulso e perderá seu lugar. Neste caso, um validador pode re-fazer staking após duas épocas, e começar a assinar blocos novamente após três épocas.
+
+## Quais são as responsabilidades de um validador?
+
+Em linhas gerais, os validadores devem executar o nó e geralmente estar online. Além disso, eles precisam estar constantemente conectados ao [chat oficial do Slack](https://near.chat) no canal `#community-validator-announcement`, para o caso de emergências e hard forks futuros. Além disso, é muito importante manter as chaves privadas seguras, caso contrário os adversários podem usá-las para assinar blocos maliciosos e acionar o slashing do protocolo.
+
+## Posso fazer stake em um shard diferente?
+
+Não há como um validador escolher o shard. O protocolo atribui aleatoriamente validadores a shards no início de cada época. O nó possui uma época para baixar seu estado. Os nós NEAR têm uma rotina automática de 'coleta de lixo' que deleta o estado de shards anteriores após cinco épocas, para liberar armazenamento não utilizado. Grandes validadores terão que gerar blocos assinando em vários shards, portanto é importante dimensionar o servidor e a rede adequadamente.
+
+## Como eu executo um nó?
+
+Siga [este tutorial.](/docs/develop/node/validator/running-a-node)
+
+## Os validadores recebem incentivos para testar o protocolo?
+
+Não oferecemos recompensas aos validadores neste momento. No entanto, podemos oferecer recompensas por relatar bugs críticos ou contribuições valiosas para a base de código no [GitHub](https://github.com/near/nearcore). Fique de olho nos itens marcados como "good first issue" (bom problema para começar). Enquanto isso, junte-se ao canal `#community-validator-announcement` em nosso [Slack oficial](https://near.chat) para ser atualizado constantemente, e ser o primeiro a saber se tencionarmos oferecer incentivos no futuro.
+
+## Como funciona a delegação de staking?
+
+A NEAR não implementa delegação no nível do protocolo. Em vez disso, a NEAR permite que contratos inteligentes façam stake, porque na NEAR contas e contratos são a mesma coisa.
+
+Assim, se os validadores quiserem aceitar stake delegado, eles têm de implementar um contrato com regras específicas sobre como funciona a delegação e a distribuição de recompensas e anunciar tal contrato como destino para delegar.  Veja a [documentação sobre delegação](/docs/validator/delegation) para mais detalhes.
+
+## Onde posso encontrar a pasta neardev/?
+
+_Ultima atualização: ???_
+
+Uma vez que você executar 'near login', uma pasta, chamada 'neardev', será criada no diretório no qual você executou 'login near'.
+
+## Posso ser um validador na rede TestNet?
+
+_Ultima atualização: ???_
+
+Atualmente não. As redes MainNet e TestNet são executadas apenas por um conjunto de validadores permissionados. Se você quiser testar a sua configuração, você pode configurar o seu nó para executar na BetaNet, seguindo o tutorial no [Github](https://github.com/nearprotocol/stakewars) e solicitando alguns tokens da BetaNet através [deste formulário](https://forms.gle/kZk2Gv79TB9qm3KP7).
+
+## Por que meu nó foi expulso do processo de validação na BetaNet?
+
+_Ultima atualização: ???_
+
+Considerando que você esteja executando na betanet, você pode ser expulso por seu nó não estar produzindo blocos suficientes. Tente novamente ou relate um problema no [GitHub](https://github.com/nearprotocol/stakewars) se você estiver passando por problemas recorrentes.
+
+Por favor, note que às vezes tivemos que reiniciar a BetaNet, e os nós podem precisar ser reinstalados para funcionar corretamente. Normalmente anunciamos essas atualizações em nosso canal oficial `#community-validator-announcement` no nosso [Slack oficial](https://near.chat) e no repositório Stake Wars no [Github](https://github.com/nearprotocol/stakewars).
+
+## Após fazer login usando o NEAR CLI com 'near login', eu sempre recebo uma mensagem de erro “Exceeded 10 status check attempts.” Como posso resolver isso?
+
+_Ultima atualização: ???_
+
+Isso significa que algo está quebrado na carteira, por favor nos contate no Slack para investigar o problema.
+
+## Alguém poderia me delegar como validador sem permissão?
+
+_Ultima atualização: 20200501_
+
+É importante recordar que a delegação não é implementada no nível do protocolo, o que significa que cada validador pode ter seu próprio contrato que ele usa para atrair delegadores. É esperado que a delegação não exija permissão, mas é claro que os validadores podem escrever seus próprios contratos de staking para que tenham permissão, se quiserem. Além disso, eles também decidem taxas de comissão e como a distribuição de recompensas funciona.
+
+## Meu stake foi delegado mas as recompensas não estão aparecendo. Como posso vê-las?
+
+_Ultima atualização: 20201022_
+
+Se uma piscina de staking não teve uma ação aplicada a ela recentemente (como alguém delegando ou deixando de delegar), ela mostrará um saldo antigo em todas as contas com stake (o que pode aparecer na sua conta da carteira).  Para ver um saldo atualizado, você pode "pingar" a piscina. Veja a [documentação sobre delegação](/docs/validator/delegation) e procure por `ping` para saber como fazer isso.
+
+Tem alguma dúvida?  [Pergunte no StackOverflow!](https://stackoverflow.com/questions/tagged/nearprotocol)

--- a/validators-and-staking/faq.md
+++ b/validators-and-staking/faq.md
@@ -1,5 +1,10 @@
 # FAQ
 
+## Translations
+
+* [Portuguese](faq-pt.md)
+* Add your language too via [Github pull request](https://github.com/near/docs/pull/385)
+
 ## What is a validator?
 
 We use validator as the name for nodes that are engaged in building and maintaining the network. There are three different roles validators are automatically selected to do:


### PR DESCRIPTION
This is the second contribution from Portuguese Guild to the NEAR wiki
(the first translation was about [Running a Validator node](https://github.com/near/docs/pull/816)).

Our translation efforts are coordinated through
- https://crowdin.com/project/near-documentation
- https://github.com/NEAR-Portuguese-Community/NEARCrowdinTranslations